### PR TITLE
Refactors _load_csv for faster calls

### DIFF
--- a/iso18245/__init__.py
+++ b/iso18245/__init__.py
@@ -36,8 +36,8 @@ _cached_csv: Dict[str, List[List[str]]] = {}
 
 
 def _load_csv(path: str) -> List[List[str]]:
-	full_path = resource_filename("iso18245", os.path.join("data", path))
 	if path not in _cached_csv:
+		full_path = resource_filename("iso18245", os.path.join("data", path))
 		with open(full_path, "r") as f:
 			reader = csv.reader(f)
 			_cached_csv[path] = list(reader)[1:]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ python = "^3.8"
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.2.0"
 pre-commit = "^3.2.2"
+types-setuptools = "^68.0.0.3"
 
 [build-system]
 requires = ["poetry_core>=1.5.0"]


### PR DESCRIPTION
The call to resource_filename is surprisingly expensive to make. Since it's only needed if the CSV content has not been cached, moving it inside the if statement improves the performance of this method significantly.

Closes #4