### PR TITLE
Adds field typing to MCC and MCCRange

### DIFF
--- a/iso18245/__init__.py
+++ b/iso18245/__init__.py
@@ -36,8 +36,8 @@ _cached_csv: Dict[str, List[List[str]]] = {}
 
 
 def _load_csv(path: str) -> List[List[str]]:
-	full_path = resource_filename("iso18245", os.path.join("data", path))
 	if path not in _cached_csv:
+		full_path = resource_filename("iso18245", os.path.join("data", path))
 		with open(full_path, "r") as f:
 			reader = csv.reader(f)
 			_cached_csv[path] = list(reader)[1:]

--- a/iso18245/__init__.py
+++ b/iso18245/__init__.py
@@ -1,7 +1,6 @@
 import csv
 import os.path
-from collections import namedtuple
-from typing import Dict, List
+from typing import Dict, List, NamedTuple
 
 from pkg_resources import resource_filename
 
@@ -16,21 +15,24 @@ class InvalidMCC(ValueError):
 	pass
 
 
-MCC = namedtuple(
-	"MCC",
-	(
-		"mcc",
-		"range",
-		"iso_description",
-		"usda_description",
-		"stripe_description",
-		"stripe_code",
-		"visa_description",
-		"visa_req_clearing_name",
-		"alipay_description",
-	),
-)
-MCCRange = namedtuple("MCCRange", ("start", "end", "description", "reserved"))
+class MCCRange(NamedTuple):
+	start: str
+	end: str
+	description: str
+	reserved: bool
+
+
+class MCC(NamedTuple):
+	mcc: str
+	range: MCCRange
+	iso_description: str
+	usda_description: str
+	stripe_description: str
+	stripe_code: str
+	visa_description: str
+	visa_req_clearing_name: str
+	alipay_description: str
+
 
 _cached_csv: Dict[str, List[List[str]]] = {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ python = "^3.8"
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.2.0"
 pre-commit = "^3.2.2"
+types-setuptools = "^68.0.0.3"
 
 [build-system]
 requires = ["poetry_core>=1.5.0"]


### PR DESCRIPTION
Declaring these as classes, rather than using the namedtuple function,
allows the properties to have types that are more specific than `Any`.
