### PR TITLE
fix: Fix Any import after update version

### DIFF
--- a/iso18245/__init__.py
+++ b/iso18245/__init__.py
@@ -1,6 +1,6 @@
 import csv
 from importlib.resources import files
-from typing import Dict, List, NamedTuple
+from typing import Any, Dict, List, NamedTuple
 
 ISO_VERSION_YEAR = 2003
 


### PR DESCRIPTION
After last update lib usage and execution is broken because of a missing import of `Any` type. This PR just add this import fixing the problem.

Logs:

```
tests/helpers/faker_inst/primitive_faker_provider.py:4: in <module>
    import iso18245 as merchant_category_codes
/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/site-packages/iso18245/__init__.py:182: in <module>
    def get_all_mccs_dict() -> List[Dict[str, Any]]:
                                              ^^^
E   NameError: name 'Any' is not defined
```

 